### PR TITLE
Updated `async` package version;

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
         "css-loader": "^6.6.0",
         "css-minimizer-webpack-plugin": "^3.4.1",
         "resolve-url-loader": "^5.0.0",
-        "postcss": "^8.4.4"
+        "postcss": "^8.4.4",
+        "async": "^2.6.4"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2525,15 +2525,10 @@ ast-types-flow@^0.0.7:
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
   integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
 
-async@0.9.x:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
-  integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
-
-async@^2.6.2:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
-  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
+async@0.9.x, async@^2.6.2, async@^2.6.4:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
+  integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
   dependencies:
     lodash "^4.17.14"
 


### PR DESCRIPTION
## Updated `async` package version

| Q             | A                                                           |
|---------------|-------------------------------------------------------------|
| Version       | 1.0 |
| Type          | feature            |
| License       | MIT                                                         |

### Summary (*)


The latest possible version that can be installed is 0.9.2 because of the following conflicting dependency:

```bash
react-scripts@5.0.1 requires async@0.9.x via a transitive dependency on jake@10.8.2
```

The earliest fixed version is `2.6.4`.


